### PR TITLE
label font size

### DIFF
--- a/packages/final-form-generator-mui/src/fields/FormCheckbox.js
+++ b/packages/final-form-generator-mui/src/fields/FormCheckbox.js
@@ -3,15 +3,22 @@ import React from 'react';
 import {Field} from 'react-final-form';
 import Checkbox from '@material-ui/core/Checkbox';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
+import {renderLabelTypography} from './utils/label-typography';
 
 type PropsType = {
 	label: string,
 	name: string,
 	style?: Object,
+	fontSizeLabel?: string,
 	type?: string,
 };
 
-const FormCheckbox = ({label, type, ...props}: PropsType) => (
+const FormCheckbox = ({
+	label,
+	type,
+	fontSizeLabel = '1em',
+	...props
+}: PropsType) => (
 	<Field type="checkbox" {...props}>
 		{({input: {name, onChange, ...restInput}, ...rest}) => (
 			<FormControlLabel
@@ -24,7 +31,7 @@ const FormCheckbox = ({label, type, ...props}: PropsType) => (
 						{...rest}
 					/>
 				}
-				label={label}
+				label={renderLabelTypography({optionLabel: label, fontSizeLabel})}
 			/>
 		)}
 	</Field>

--- a/packages/final-form-generator-mui/src/fields/FormCheckboxGroup.js
+++ b/packages/final-form-generator-mui/src/fields/FormCheckboxGroup.js
@@ -7,7 +7,7 @@ import FormGroup from '@material-ui/core/FormGroup';
 import FormHelperText from '@material-ui/core/FormHelperText';
 import FormLabel from '@material-ui/core/FormLabel';
 
-import type {LabelPlacementTye, OptionType} from '../types';
+import type {LabelPlacementType, OptionType} from '../types';
 import FormCheckbox from './FormCheckbox';
 
 const useStyles = makeStyles(theme => ({
@@ -24,7 +24,8 @@ type PropsType = {
 	name: string,
 	options: OptionType[],
 	style?: Object,
-	labelPlacement?: LabelPlacementTye,
+	labelPlacement?: LabelPlacementType,
+	fontSizeLabel?: string,
 	row?: boolean,
 };
 
@@ -35,6 +36,7 @@ const FormCheckboxGroup = ({
 	options,
 	row,
 	style,
+	fontSizeLabel = '1em',
 }: PropsType) => {
 	const classes = useStyles();
 	return (
@@ -54,6 +56,7 @@ const FormCheckboxGroup = ({
 								name={name}
 								label={optionLabel}
 								labelPlacement={labelPlacement}
+								fontSizeLabel={fontSizeLabel}
 								value={optionValue}
 							/>
 						))}

--- a/packages/final-form-generator-mui/src/fields/FormRadio.js
+++ b/packages/final-form-generator-mui/src/fields/FormRadio.js
@@ -3,15 +3,22 @@ import React from 'react';
 import {Field} from 'react-final-form';
 import Radio from '@material-ui/core/Radio';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
+import {renderLabelTypography} from './utils/label-typography';
 
 type PropsType = {
 	label: string,
 	name: string,
 	type?: string,
+	fontSizeLabel?: string,
 	style?: Object,
 };
 
-const FormRadio = ({label, type, ...props}: PropsType) => (
+const FormRadio = ({
+	label,
+	type,
+	fontSizeLabel = '1em',
+	...props
+}: PropsType) => (
 	<Field type="radio" {...props}>
 		{({input: {checked, value, name, onChange, ...restInput}, ...rest}) => (
 			<FormControlLabel
@@ -25,7 +32,7 @@ const FormRadio = ({label, type, ...props}: PropsType) => (
 						{...rest}
 					/>
 				}
-				label={label}
+				label={renderLabelTypography({optionLabel: label, fontSizeLabel})}
 			/>
 		)}
 	</Field>

--- a/packages/final-form-generator-mui/src/fields/FormRadioGroup.js
+++ b/packages/final-form-generator-mui/src/fields/FormRadioGroup.js
@@ -9,7 +9,8 @@ import RadioGroup from '@material-ui/core/RadioGroup';
 import FormHelperText from '@material-ui/core/FormHelperText';
 import {makeStyles} from '@material-ui/styles';
 
-import type {LabelPlacementTye, OptionType} from '../types';
+import type {LabelPlacementType, OptionType} from '../types';
+import {renderLabelTypography} from './utils/label-typography';
 
 const useStyles = makeStyles(theme => ({
 	formControl: {
@@ -24,7 +25,8 @@ type PropsType = {
 	label: string,
 	name: string,
 	options: OptionType[],
-	labelPlacement?: LabelPlacementTye,
+	labelPlacement?: LabelPlacementType,
+	fontSizeLabel?: string,
 	row?: boolean,
 	style?: Object,
 };
@@ -34,6 +36,7 @@ const FormRadioGroup = ({
 	labelPlacement = 'end',
 	row,
 	style,
+	fontSizeLabel = '1em',
 	options,
 	...props
 }: PropsType) => {
@@ -67,7 +70,7 @@ const FormRadioGroup = ({
 								key={`${name}-radio-${optionValue}`}
 								value={optionValue}
 								control={<Radio color="primary" />}
-								label={optionLabel}
+								label={renderLabelTypography({optionLabel, fontSizeLabel})}
 								labelPlacement={labelPlacement}
 							/>
 						))}

--- a/packages/final-form-generator-mui/src/fields/utils/label-typography.js
+++ b/packages/final-form-generator-mui/src/fields/utils/label-typography.js
@@ -1,0 +1,12 @@
+// @flow
+
+import React from 'react';
+import {Typography} from '@material-ui/core';
+
+export const renderLabelTypography = ({
+	optionLabel,
+	fontSizeLabel,
+}: {
+	optionLabel: string,
+	fontSizeLabel: string,
+}) => <Typography style={{fontSize: fontSizeLabel}}>{optionLabel}</Typography>;

--- a/packages/final-form-generator-mui/src/types.js
+++ b/packages/final-form-generator-mui/src/types.js
@@ -10,7 +10,7 @@ export type OptionType = {|label: string, value: any|};
 
 export type VariantType = 'standard' | 'outlined' | 'filled';
 
-export type LabelPlacementTye = 'end' | 'start' | 'top' | 'bottom';
+export type LabelPlacementType = 'end' | 'start' | 'top' | 'bottom';
 // End of common types
 
 //
@@ -20,7 +20,7 @@ export type CheckboxFieldType = BasicInputType<'checkbox'>;
 export type CheckboxGroupFieldType = $ReadOnly<{|
 	...BasicInputType<'checkbox-group'>,
 	options: OptionType[],
-	labelPlacement?: LabelPlacementTye,
+	labelPlacement?: LabelPlacementType,
 	row?: boolean,
 |}>;
 export type FileFieldType = $ReadOnly<{|
@@ -41,7 +41,7 @@ export type RadioFieldType = BasicInputType<'radio'>;
 export type RadioGroupFieldType = $ReadOnly<{|
 	...BasicInputType<'radio-group'>,
 	options: OptionType[],
-	labelPlacement?: LabelPlacementTye,
+	labelPlacement?: LabelPlacementType,
 	row?: boolean,
 |}>;
 


### PR DESCRIPTION
Permet de choisir la taille du texte des options (checkbox et radio) en utilisant `fontSizeLabel`, exemple : 
```js
{
	label: 'Multiple radio',
	type: 'radio-group',
	name: 'multipleRadio',
	validation: Yup.string().required(),
        fontSizeLabel: '1.875rem',
	options: [...],
},
```