### PR TITLE
variant field

### DIFF
--- a/packages/final-form-generator-mui-example/src/components/FormExample.js
+++ b/packages/final-form-generator-mui-example/src/components/FormExample.js
@@ -1,7 +1,9 @@
 // @flow
 import React from 'react';
 import * as Yup from 'yup';
-import FinalFormGenerator from '@kyump/final-form-generator-mui';
+import FinalFormGenerator, {
+	useRenderVariantFields,
+} from '@kyump/final-form-generator-mui';
 import Paper from '@material-ui/core/Paper';
 
 type PropsType = {columns: number};
@@ -231,7 +233,7 @@ const fields = [
 
 const FormExample = ({columns}: PropsType) => (
 	<FinalFormGenerator
-		fields={fields}
+		fields={useRenderVariantFields({fields, variant: 'filled'})}
 		columns={columns}
 		onSubmit={values => alert(values)}
 		devMode

--- a/packages/final-form-generator-mui/src/index.js
+++ b/packages/final-form-generator-mui/src/index.js
@@ -2,6 +2,7 @@
 import MuiForm from './MuiForm';
 
 export {useMuiFormGenerator} from './mui-form-generator';
+export {useRenderVariantFields} from './variant-fields';
 export {default as FormComponent} from './FormComponent';
 
 export default MuiForm;

--- a/packages/final-form-generator-mui/src/variant-fields.js
+++ b/packages/final-form-generator-mui/src/variant-fields.js
@@ -1,0 +1,36 @@
+// @flow
+
+import type {FieldType} from './types';
+
+export const useRenderVariantFields = ({
+	fields,
+	variant,
+}: {
+	// $FlowFixMe
+	fields: Array<FieldType>,
+	variant: string,
+}): Array<FieldType> => {
+	fields.map(field => {
+		if (
+			![
+				'container',
+				'condition',
+				'checkbox',
+				'checkbox-group',
+				'radio',
+				'radio-group',
+			].includes(field.type)
+		) {
+			// $FlowFixMe
+			field.variant = variant;
+			return field;
+		}
+		if (['container', 'condition'].includes(field.type) && field.fields) {
+			// $FlowFixMe
+			field.fields = useRenderVariantFields({fields: field.fields, variant});
+			return field;
+		}
+		return field;
+	});
+	return fields;
+};


### PR DESCRIPTION
Permet d'utiliser le variant sur tout le formulaire avec la fonction `useRenderVariantFields`:
```js
<FinalFormGenerator
	fields={useRenderVariantFields({fields, variant: 'filled'})}
	columns={columns}
	onSubmit={values => alert(values)}
	devMode
/>
```